### PR TITLE
Add Adanos Market Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A curated list of amazingly awesome financial libraries, resources and shiny thi
 * [yahoo-finance](https://github.com/herval/yahoo-finance) - Ruby's Yahoo Finance Wrapper.
 
 ### Others
+* [Adanos Market Sentiment API](https://api.adanos.org/docs) - Market sentiment data API for US equities from Reddit, X / FinTwit, news, and Polymarket, with Python and TypeScript SDKs.
 * [awesome-x402](https://github.com/xpaysh/awesome-x402) - A curated list of resources for the x402 HTTP 402 payment protocol, enabling programmatic cryptocurrency payments over HTTP using USDC.
 * [payment-webfont](https://github.com/orlandotm/payment-webfont) - An SVG webfont full of main payment system icons.
 


### PR DESCRIPTION
## Summary
- Add Adanos Market Sentiment API to the cross-language resources section
- Link directly to the public API documentation
- Mention the available Python and TypeScript SDKs for developers

This replaces the earlier closed #42 with a more direct docs link and API-focused wording.

## Checks
- Reviewed README structure and existing entry style
- Confirmed no existing Adanos entry or open Adanos PR
- Ran `git diff --check`